### PR TITLE
Re-enable single start and single goal parameters

### DIFF
--- a/cbirrt2/src/cbirrtpy/CBiRRT.py
+++ b/cbirrt2/src/cbirrtpy/CBiRRT.py
@@ -159,7 +159,7 @@ class CBiRRT(object):
                     cmd.append(len(jointgoal))
                     cmd.extend(jointgoal)
             except (AssertionError, TypeError):  # Fall back to single list of goals
-                # "jointgoals" will have already been appended
+                cmd.append("jointgoals")
                 cmd.append(len(jointgoals))
                 cmd.extend(jointgoals)
 
@@ -171,7 +171,7 @@ class CBiRRT(object):
                     cmd.append(len(jointstart))
                     cmd.extend(jointstart)
             except (AssertionError, TypeError):  # Fall back to single list of starts
-                # "jointstarts" will have already been appended
+                cmd.append("jointstarts")
                 cmd.append(len(jointstarts))
                 cmd.extend(jointstarts)
 


### PR DESCRIPTION
https://github.com/UM-ARM-Lab/comps/commit/b9620b326e3a061443da2073026c4d1ef26a6f5e broke single start/single goal parameters due to the assertion triggering before the appropriate command was added to the command list. This fixes that.